### PR TITLE
Add HTTP API

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,11 +13,17 @@ function makeError(response, message, code) {
 	});
 }
 
+function validName(name) {
+	return !(name.replace(/[^a-zA-Z]/g, "").match(/server/gi));
+}
+
 app.post("/api/v1/message", (req, res) => {
 	if (!req.body || Object.keys(req.body).length === 0) {
 		return makeError(res, "Provide a body.", 1);
 	} else if (!req.body.content) {
 		return makeError(res, "Provide content for the message.", 2);
+	} else if (req.body.nickname && !validName(req.body.nickname)) {
+		return makeError(res, "The nickname is invalid.", 3);
 	} else {
 		const msg = {
 			message: req.body.content,
@@ -61,7 +67,7 @@ io.on("connection", socket => {
 	let dabCount = 0;
 
 	function setName(newID, silent) {
-		if (newID.replace(/[^a-zA-Z]/g, "").match(/server/gi)) {
+		if (!validName(newID)) {
 			if (!silent) {
 				sys("Don't impersonate the server.");
 			}

--- a/index.js
+++ b/index.js
@@ -14,6 +14,10 @@ function makeError(response, message, code) {
 }
 
 function validName(name) {
+	if (typeof name !== "string") {
+		return false;
+	}
+
 	return !(name.replace(/[^a-zA-Z]/g, "").match(/server/gi));
 }
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,32 @@ const app = e();
 const bodyParser = require('body-parser');
 app.use(bodyParser.json());
 
+function makeError(response, message, code) {
+	return response.json({
+		error: {
+			message,
+			code,
+		},
+	});
+}
+
+app.post("/api/v1/message", (req, res) => {
+	if (!req.body || Object.keys(req.body).length === 0) {
+		return makeError(res, "Provide a body.", 1);
+	} else if (!req.body.content) {
+		return makeError(res, "Provide content for the message.", 2);
+	} else {
+		const msg = {
+			message: req.body.content,
+			who: req.body.nickname || "Unknown",
+			color: "black",
+		};
+		io.emit("msg", msg);
+
+		return res.json(msg);
+	}
+});
+
 const http = require("http")
 const serv = http.Server(app);
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 const e = require("express");
 const app = e();
 
+const bodyParser = require('body-parser');
+app.use(bodyParser.json());
+
 const http = require("http")
 const serv = http.Server(app);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"main": "index.js",
 	"dependencies": {
+		"body-parser": "^1.18.3",
 		"express": "4.16.4",
 		"socket.io": "2.2.0",
 		"short-id": "0.1.0-1",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "main": "index.js",
-  "dependencies": {
-    "express": "4.16.4",
-    "socket.io": "2.2.0",
-    "short-id": "0.1.0-1",
-    "ordinal": "1.0.2"
-  }
+	"main": "index.js",
+	"dependencies": {
+		"express": "4.16.4",
+		"socket.io": "2.2.0",
+		"short-id": "0.1.0-1",
+		"ordinal": "1.0.2"
+	}
 }


### PR DESCRIPTION
This pull request adds an HTTP API with one endpoint: `POST /api/v1/message`. This endpoint should have the fields:

```json
{
	"nickname": "Sender",
	"content": "A message to send."
}
```

If there is an error, it will be returned in this format:

```json
{
    "error": {
        "message": "A somewhat descriptive error message.",
        "code": 999
    }
}
```